### PR TITLE
Set R102 as latest

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,8 +34,8 @@
     		<img slot="nav-logo" src="./static/logo.svg" style="height: 32px" />
 			<div id="versionSelectWrapper" style="font-family: var(--font-regular), sans-serif; color: white; position:absolute; bottom: 10px; left:10px;">
 				Version: <select id="versionSelect">
-				    <option selected="selected" value="openapi_latest">R102</option>
-				    <option selected="selected" value="r101/openapi">R101 (Current)</option>
+				    <option selected="selected" value="openapi_latest">R102 (Current)</option>
+				    <option value="r101/openapi">R101</option>
 				    <option value="r100/openapi">R100</option>
 				    <option value="r99/openapi">R99</option>
 					<option value="r98/openapi">R98</option>


### PR DESCRIPTION
## Summary

Promotes **R102** to be the current/latest OpenAPI definition shown in the version selector.

## Changes

In `index.html`, the version dropdown now reflects R102 as the current release, following the same convention used in the previous "Set R101 as latest" change:

- `R102` → marked `(Current)` and kept `selected`
- `R101` → demoted from `(Current)`, no longer `selected`

## Testing

Documentation-only change to the RapiDoc version selector; no API definitions were modified.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqCHLMEjRTSDa6YDByp7GS)_