### PR TITLE
Set OpenAPI info.version to 103.0

### DIFF
--- a/definitions/openapi_latest.json
+++ b/definitions/openapi_latest.json
@@ -12,7 +12,7 @@
       "name" : "BlueConic",
       "url" : "https://github.com/blueconic/openapi/blob/main/LICENSE.MD"
     },
-    "version" : "103.0-SNAPSHOT"
+    "version" : "103.0"
   },
   "servers" : [ {
     "url" : "https://{blueconicHostname}/rest/v2",

--- a/definitions/openapi_latest.yaml
+++ b/definitions/openapi_latest.yaml
@@ -107,7 +107,7 @@ info:
   license:
     name: BlueConic
     url: https://github.com/blueconic/openapi/blob/main/LICENSE.MD
-  version: 103.0-SNAPSHOT
+  version: "103.0"
 servers:
 - url: "https://{blueconicHostname}/rest/v2"
   description: The BlueConic server


### PR DESCRIPTION
## Summary
- `openapi_latest` `info.version` is now `103.0` (was `103.0-SNAPSHOT`).
- Spec was generated from SNAPSHOT; R103 is published as the 103.0 major release.


Made with [Cursor](https://cursor.com)